### PR TITLE
Use server time zone when displaying last run

### DIFF
--- a/app/controllers/clockwork_web/home_controller.rb
+++ b/app/controllers/clockwork_web/home_controller.rb
@@ -19,7 +19,7 @@ module ClockworkWeb
 
       @last_runs = ClockworkWeb.last_runs
       @disabled = ClockworkWeb.disabled_jobs
-      @last_heartbeat = ClockworkWeb.last_heartbeat
+      @last_heartbeat = ClockworkWeb.last_heartbeat.in_time_zone
     end
 
     def job

--- a/app/helpers/clockwork_web/home_helper.rb
+++ b/app/helpers/clockwork_web/home_helper.rb
@@ -15,7 +15,7 @@ module ClockworkWeb
 
     def last_run(time)
       if time
-        time_ago_in_words(time)
+        time_ago_in_words(time.in_time_zone)
       end
     end
 


### PR DESCRIPTION
This PR changes the output of `heartbeat` and `last run` values, they are formatted using current time zone.