### PR TITLE
Support conditional engine loading when Rails is not required

### DIFF
--- a/lib/clockwork_web.rb
+++ b/lib/clockwork_web.rb
@@ -3,7 +3,7 @@ require "clockwork"
 require "safely/core"
 
 # modules
-require_relative "clockwork_web/engine"
+require_relative "clockwork_web/engine" if defined?(Rails)
 require_relative "clockwork_web/version"
 
 module ClockworkWeb


### PR DESCRIPTION
For people using a very lightweight clock configuration file (without requiring the entirety of Rails), this allows the engine file to not be required while still using the hooks for heartbeats etc.