### PR TITLE
Add new Run Now button + fix on callback

### DIFF
--- a/app/controllers/clockwork_web/home_controller.rb
+++ b/app/controllers/clockwork_web/home_controller.rb
@@ -35,5 +35,16 @@ module ClockworkWeb
       ClockworkWeb.on_job_update.call(job: job, enable: enable, user: try(ClockworkWeb.user_method)) if ClockworkWeb.on_job_update
       redirect_to root_path
     end
+
+    def execute
+      job = params[:job]
+
+      event = Clockwork.manager.events.find { _1.job == params[:job] }
+
+      event.run(Time.now)
+      ClockworkWeb.set_last_run(event.job)
+
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/clockwork_web/home/index.html.erb
+++ b/app/views/clockwork_web/home/index.html.erb
@@ -51,6 +51,10 @@
       .width-15 {
         width: 15%;
       }
+
+      .button-form {
+        display: inline-block;
+      }
     <% end %>
   </head>
   <body>
@@ -80,7 +84,7 @@
             <th>Job</th>
             <th class="width-15">Period</th>
             <th class="width-15">Last Run</th>
-            <th class="width-15">Action</th>
+            <th class="width-15">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -99,7 +103,10 @@
                 <% end %>
               </td>
               <td><%= last_run(@last_runs[event.job]) %></td>
-              <td><%= button_to enabled ? "Disable" : "Enable", home_job_path(job: event.job, enable: !enabled), disabled: !ClockworkWeb.redis %></td>
+              <td>
+                <%= button_to enabled ? "Disable" : "Enable", home_job_path(job: event.job, enable: !enabled), disabled: !ClockworkWeb.redis, form_class: 'button-form' %>
+                <%= button_to "Run now", home_execute_path(job: event.job), disabled: !ClockworkWeb.redis, form_class: 'button-form' %>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 ClockworkWeb::Engine.routes.draw do
   post "home/job"
+  post "home/execute"
+
   root to: "home#index"
 end


### PR DESCRIPTION
There are times where we don't want to wait for the event to happen and manually execute/run the event.

This PR introduces:
-  a new `Run now` button next to the `Enable/Disable` button
   - After carefully reading `clockwork` source code, using `event.run(Time.now)` handles the setting of `event.last` 
   - it also calls `set_last_run` to update redis as well.
- Setting Last run in `after_run` callback
  - I usually have `every(1.minutes, 'job_name') { SomeSidekiqJob.perform_async }`
  - What can happen here, is that the block can raise an exception. For my case, it can be redis ( the one for Sidekiq not clockwork_web) is down or Out Of Memory for example. But it can also be any ruby error 
  - So setting "last_run" on Clockwork_web's redis after being run is a safer and more accurate way to set it than setting it before it's run, which can be misleading
  
  Here is a screenshot: 
  
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/1a77b1ba-0aca-4330-ab3d-23cf46f43c82">

