### PR TITLE
Display `if` block/lambda instead of `__` placeholder

### DIFF
--- a/app/helpers/clockwork_web/home_helper.rb
+++ b/app/helpers/clockwork_web/home_helper.rb
@@ -25,5 +25,21 @@ module ClockworkWeb
         "**"
       end
     end
+
+    def friendly_extract_source_from_callable(callable, with_affixes: true)
+      source = RubyVM::AbstractSyntaxTree.of(callable, keep_script_lines: true).source
+      return '-' unless source
+
+      source.strip!
+      return source if with_affixes
+
+      source.tap do |source|
+        source.delete_prefix!('{')
+        source.delete_suffix!('}')
+
+        source.delete_prefix!('do')
+        source.delete_suffix!('end')
+      end
+    end
   end
 end

--- a/app/views/clockwork_web/home/index.html.erb
+++ b/app/views/clockwork_web/home/index.html.erb
@@ -77,7 +77,7 @@
       <table>
         <thead>
           <tr>
-            <th>Job</th>
+            <th class="width-15">Job</th>
             <th class="width-15">Period</th>
             <th class="width-15">Last Run</th>
             <th class="width-15">Action</th>
@@ -94,8 +94,8 @@
                 <% if at %>
                   at <%= friendly_time_part(at.instance_variable_get(:@hour)) %>:<%= friendly_time_part(at.instance_variable_get(:@min)) %>
                 <% end %>
-                <% if event.instance_variable_get(:@if) %>
-                  if __
+                <% if if_lambda = event.instance_variable_get(:@if) %>
+                  if: -> <%= friendly_extract_source_from_callable(if_lambda)%>
                 <% end %>
               </td>
               <td><%= last_run(@last_runs[event.job]) %></td>


### PR DESCRIPTION
Using RubyVM ast new API, we can simple get a hold of the source of lambda/block.

This replaces the `__` placeholder by the actual implementation of the `@if` lambda

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/7cd803c6-5540-47e8-8134-44b706aaa0ff">
