### PR TITLE
Add job block implementation in index page

### DIFF
--- a/app/helpers/clockwork_web/home_helper.rb
+++ b/app/helpers/clockwork_web/home_helper.rb
@@ -25,5 +25,21 @@ module ClockworkWeb
         "**"
       end
     end
+
+    def friendly_extract_source_from_callable(callable, with_affixes: true)
+      source = RubyVM::AbstractSyntaxTree.of(callable, keep_script_lines: true).source
+      return '-' unless source
+
+      source.strip!
+      return source if with_affixes
+
+      source.tap do |source|
+        source.delete_prefix!('{')
+        source.delete_suffix!('}')
+
+        source.delete_prefix!('do')
+        source.delete_suffix!('end')
+      end
+    end
   end
 end

--- a/app/views/clockwork_web/home/index.html.erb
+++ b/app/views/clockwork_web/home/index.html.erb
@@ -79,6 +79,7 @@
           <tr>
             <th>Job</th>
             <th class="width-15">Period</th>
+            <th class="width-15">Implementation block</th>
             <th class="width-15">Last Run</th>
             <th class="width-15">Action</th>
           </tr>
@@ -96,6 +97,16 @@
                 <% end %>
                 <% if event.instance_variable_get(:@if) %>
                   if __
+                <% end %>
+              </td>
+              <td>
+                <% if block = event.instance_variable_get(:@block) %>
+                  <details>
+                    <summary>Click to see implementation</summary>
+                    {
+                    <%= friendly_extract_source_from_callable(block, with_affixes: false) %>
+                    }
+                  </details>
                 <% end %>
               </td>
               <td><%= last_run(@last_runs[event.job]) %></td>


### PR DESCRIPTION
Related to #9 

With this new column, the index has a full and complete picture of each job/event. Without ever needing to jump back and forth between `clock.rb` and the UI web page

By default the implementation source is not expanded. but can be with the `summary/details` combination

Screeshot: 

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/519e5196-7aa7-4ff4-b94c-66afbd72d704">

